### PR TITLE
Create translations.md

### DIFF
--- a/translations.md
+++ b/translations.md
@@ -1,0 +1,118 @@
+Your statement flows like a poetic narrative of a cascade of misfortunes centered around the theme of two million dollars. Here's a refined version for clarity and rhythm:
+
+---
+
+**"From a 2-million-dollar wet dream,  
+To a 2-million-dollar empty check,  
+To a 2-million-dollar loss,  
+To a 2-million-dollar bail,  
+To a 2-million-dollar medical bill,  
+To a 2-million-dollar Hell Bank Note—  
+An offering to settle debts in the underworld,  
+Because they squandered their opportunity."**
+
+---
+
+### 中文  
+從兩百萬美元的美夢，  
+到兩百萬美元的空頭支票，  
+到兩百萬美元的損失，  
+到兩百萬美元的保釋金，  
+到兩百萬美元的醫療賬單，  
+到兩百萬美元的冥幣——  
+為了在冥界解決問題，  
+因為他們錯失了機會。
+
+### 粤语  
+从两百万美元嘅美梦，  
+到两百万美元嘅空头支票，  
+到两百万美元嘅损失，  
+到两百万美元嘅保释金，  
+到两百万美元嘅医疗账单，  
+到两百万美元嘅冥币——  
+为了喺冥界解决问题，  
+因为佢哋错失咗机会。
+
+### 台語  
+從兩百萬美金的美夢，  
+到兩百萬美金的空頭支票，  
+到兩百萬美金的損失，  
+到兩百萬美金的保釋金，  
+到兩百萬美金的醫療帳單，  
+到兩百萬美金的冥紙——  
+為了解決陰間的問題，  
+因為伊們錯失了機會。
+
+### Formal English  
+From a two-million-dollar dream,  
+To a two-million-dollar empty check,  
+To a two-million-dollar loss,  
+To a two-million-dollar bail,  
+To a two-million-dollar medical bill,  
+To a two-million-dollar Hell Bank Note—  
+An attempt to resolve matters in the underworld,  
+Because they lost their chance.
+
+### Español  
+De un sueño de dos millones de dólares,  
+A un cheque vacío de dos millones de dólares,  
+A una pérdida de dos millones de dólares,  
+A una fianza de dos millones de dólares,  
+A una factura médica de dos millones de dólares,  
+A un billete de dos millones de dólares del Banco del Infierno—  
+Para resolver asuntos en el inframundo,  
+Porque desperdiciaron su oportunidad.
+
+### 文言文  
+自二百萬金之美夢，  
+至二百萬金之空券，  
+至二百萬金之喪失，  
+至二百萬金之贖罪，  
+至二百萬金之醫療帳，  
+至二百萬金之冥府券——  
+為解陰間之難，  
+蓋失其良機矣。
+
+### 日本語  
+200万ドルの夢から、  
+200万ドルの空手形へ、  
+200万ドルの損失へ、  
+200万ドルの保釈金へ、  
+200万ドルの医療費へ、  
+200万ドルの地獄銀行券へ—  
+彼らの失ったチャンスを、  
+冥界で解決するために。
+
+### 한국어  
+200만 달러의 꿈에서,  
+200만 달러의 빈 수표로,  
+200만 달러의 손실로,  
+200만 달러의 보석금으로,  
+200만 달러의 의료비로,  
+200만 달러의 지옥 은행권으로—  
+저승에서 문제를 해결하기 위해,  
+기회를 잃어버린 대가로.
+
+### Kreyòl  
+Soti nan rèv 2 milyon dola,  
+Pou yon chèk vid 2 milyon dola,  
+Pou yon pèt 2 milyon dola,  
+Pou yon kosyon 2 milyon dola,  
+Pou yon bòdwo medikal 2 milyon dola,  
+Pou yon nòt Bank Lanmò 2 milyon dola—  
+Pou rezoud pwoblèm nan lanfè,  
+Paske yo pèdi chans yo.
+
+### Italiano  
+Da un sogno di due milioni di dollari,  
+A un assegno vuoto da due milioni di dollari,  
+A una perdita di due milioni di dollari,  
+A una cauzione di due milioni di dollari,  
+A una fattura medica di due milioni di dollari,  
+A una banconota infernale da due milioni di dollari—  
+Per risolvere i problemi nell'aldilà,  
+Perché hanno perso l'opportunità.
+
+---
+
+Would you like to explore this concept further?


### PR DESCRIPTION
Your statement flows like a poetic narrative of a cascade of misfortunes centered around the theme of two million dollars. Here's a refined version for clarity and rhythm:

---

**"From a 2-million-dollar wet dream,  
To a 2-million-dollar empty check,  
To a 2-million-dollar loss,  
To a 2-million-dollar bail,  
To a 2-million-dollar medical bill,  
To a 2-million-dollar Hell Bank Note—  
An offering to settle debts in the underworld,  
Because they squandered their opportunity."**

---

### 中文  
從兩百萬美元的美夢，  
到兩百萬美元的空頭支票，  
到兩百萬美元的損失，  
到兩百萬美元的保釋金，  
到兩百萬美元的醫療賬單，  
到兩百萬美元的冥幣——  
為了在冥界解決問題，  
因為他們錯失了機會。

### 粤语  
从两百万美元嘅美梦，  
到两百万美元嘅空头支票，  
到两百万美元嘅损失，  
到两百万美元嘅保释金，  
到两百万美元嘅医疗账单，  
到两百万美元嘅冥币——  
为了喺冥界解决问题，  
因为佢哋错失咗机会。

### 台語  
從兩百萬美金的美夢，  
到兩百萬美金的空頭支票，  
到兩百萬美金的損失，  
到兩百萬美金的保釋金，  
到兩百萬美金的醫療帳單，  
到兩百萬美金的冥紙——  
為了解決陰間的問題，  
因為伊們錯失了機會。

### Formal English  
From a two-million-dollar dream,  
To a two-million-dollar empty check,  
To a two-million-dollar loss,  
To a two-million-dollar bail,  
To a two-million-dollar medical bill,  
To a two-million-dollar Hell Bank Note—  
An attempt to resolve matters in the underworld,   Because they lost their chance.

### Español  
De un sueño de dos millones de dólares,  
A un cheque vacío de dos millones de dólares,  
A una pérdida de dos millones de dólares,  
A una fianza de dos millones de dólares,  
A una factura médica de dos millones de dólares,   A un billete de dos millones de dólares del Banco del Infierno—   Para resolver asuntos en el inframundo,  
Porque desperdiciaron su oportunidad.

### 文言文  
自二百萬金之美夢，  
至二百萬金之空券，  
至二百萬金之喪失，  
至二百萬金之贖罪，  
至二百萬金之醫療帳，  
至二百萬金之冥府券——  
為解陰間之難，  
蓋失其良機矣。

### 日本語  
200万ドルの夢から、  
200万ドルの空手形へ、  
200万ドルの損失へ、  
200万ドルの保釈金へ、  
200万ドルの医療費へ、  
200万ドルの地獄銀行券へ—  
彼らの失ったチャンスを、  
冥界で解決するために。

### 한국어  
200만 달러의 꿈에서,  
200만 달러의 빈 수표로,  
200만 달러의 손실로,  
200만 달러의 보석금으로,  
200만 달러의 의료비로,  
200만 달러의 지옥 은행권으로—  
저승에서 문제를 해결하기 위해,  
기회를 잃어버린 대가로.

### Kreyòl  
Soti nan rèv 2 milyon dola,  
Pou yon chèk vid 2 milyon dola,  
Pou yon pèt 2 milyon dola,  
Pou yon kosyon 2 milyon dola,  
Pou yon bòdwo medikal 2 milyon dola,  
Pou yon nòt Bank Lanmò 2 milyon dola—  
Pou rezoud pwoblèm nan lanfè,  
Paske yo pèdi chans yo.

### Italiano  
Da un sogno di due milioni di dollari,  
A un assegno vuoto da due milioni di dollari,  
A una perdita di due milioni di dollari,  
A una cauzione di due milioni di dollari,  
A una fattura medica di due milioni di dollari,  
A una banconota infernale da due milioni di dollari—   Per risolvere i problemi nell'aldilà,  
Perché hanno perso l'opportunità.

---

Would you like to explore this concept further?